### PR TITLE
Scanning with name: filtering now using comparison instead of equality

### DIFF
--- a/SFBluetoothLowEnergyDevice/Classes/SFBLEDeviceFinder.m
+++ b/SFBluetoothLowEnergyDevice/Classes/SFBLEDeviceFinder.m
@@ -274,7 +274,7 @@ static dispatch_queue_t __bleQueue;
   }
 
   if ( (self.identifierToScanFor && [self.identifierToScanFor isEqual:peripheral.identifier]) ||
-      (self.nameToScanFor && [self.nameToScanFor isEqualToString:peripheral.name]) ||
+      (self.nameToScanFor && ![peripheral.name rangeOfString:self.nameToScanFor].location == NSNotFound) ||
       self.stopAfterFirstDevice)
   {
     DDLogDebug(@"BLE-Finder: did discover specific peripheral: %@", peripheral);

--- a/SFBluetoothLowEnergyDevice/Classes/SFBLEPeripheralDelegate.m
+++ b/SFBluetoothLowEnergyDevice/Classes/SFBLEPeripheralDelegate.m
@@ -187,17 +187,14 @@ static NSString* kBleServiceHeartRate = @"180D";
   [self.device.peripheral readValueForCharacteristic:characteristic];
 }
 
-
 - (void)writeValue:(NSData*)value forCharacteristic:(CBUUID*)characteristicUUID
 {
-  // TODO: allow for both types of writing (w/ and w/o response)
   CBCharacteristic* characteristic = self.characteristicsByUUID[characteristicUUID];
   [self.device.peripheral writeValue:value forCharacteristic:characteristic type:CBCharacteristicWriteWithResponse];
 }
 
 - (void)writeValueWithoutResponse:(NSData*)value forCharacteristic:(CBUUID*)characteristicUUID
 {
-  // TODO: allow for both types of writing (w/ and w/o response)
   CBCharacteristic* characteristic = self.characteristicsByUUID[characteristicUUID];
   [self.device.peripheral writeValue:value forCharacteristic:characteristic type:CBCharacteristicWriteWithoutResponse];
 }


### PR DESCRIPTION
Scanning with name: filtering now using comparison (if name is within corebluetooth’s device name) instead of checking equality
